### PR TITLE
Removed discord.py requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     package_data={'': [r'chat_exporter/chat_exporter_html/*.html']},
     include_package_data=True,
     license="GPL",
-    install_requires=["discord.py", "aiohttp", "pytz", "grapheme", "emoji"],
+    install_requires=["aiohttp", "pytz", "grapheme", "emoji"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Removed discord.py requirement for using forks of discord py like pycord, nextcord etc.
Reason for me to remove it:
On my vps I use a requirements.txt that does not include discord py because I use a fork
But this module always installs discord.py again and gets in conflict with pycord.
Please make the libary used by pycord and other forks too (see breaking changes for v2 of the forks to change certain things if needed :D)