### PR TITLE
Add explicit instructions for installing 1.7.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,20 @@ To install the repository, run the command:
 
     git clone https://github.com/mahtoid/DiscordChatExporterPy
 
-**NOTE: If you are using discord.py 1.7.3, please use chat-exporter v1.7.3**
+**Important**
+
+You can check your version of discord.py with this command:
+
+.. code:: sh
+
+    python -c 'import discord; print(discord.__version__)'
+    
+If you are using discord.py 1.7.3, please use chat-exporter 1.7.3. To install this version, run these commands:
+ 
+.. code:: sh
+ 
+    pip uninstall -y chat-exporter
+    pip install chat-exporter==1.7.3
 
 Usage
 -----


### PR DESCRIPTION
I'm used to doing:

```
import pkg
print(pkg.__version__)
```

but `chat_exporter` doesn't use `__version__`, so I was initially confused when the most "up-to-date" version of `discord.py` and `chat_exporter` (from `pip`) were not working well together. I joined the `chat_exporter` Discord just to solve my issue, and from searching in the chat history I found other people previously had the same confusion.

Adding this explicitly to the README might help others in the future, and minimise the noise on Discord.