### PR TITLE
 Retains member_id information in case of unknown mention

### DIFF
--- a/chat_exporter/parse/mention.py
+++ b/chat_exporter/parse/mention.py
@@ -118,7 +118,8 @@ class ParseMention:
                     replacement = '<span class="mention" title="%s">@%s</span>' \
                                   % (str(member_id), str(member_name))
                 else:
-                    replacement = '<span class="mention" title="Unknown">@Unknown</span>'
+                    replacement = '<span class="mention" title="%s">@Unknown</span>' \
+                                  % (str(member_id))
                 self.content = self.content.replace(self.content[match.start():match.end()],
                                                     replacement)
 

--- a/chat_exporter/parse/mention.py
+++ b/chat_exporter/parse/mention.py
@@ -114,12 +114,8 @@ class ParseMention:
                 except AttributeError:
                     member_name = member
 
-                if member is not None:
-                    replacement = '<span class="mention" title="%s">@%s</span>' \
-                                  % (str(member_id), str(member_name))
-                else:
-                    replacement = '<span class="mention" title="%s">@Unknown</span>' \
-                                  % (str(member_id))
+                replacement = '<span class="mention" title="%s">@%s</span>' \
+                              % (str(member_id), str(member_name))
                 self.content = self.content.replace(self.content[match.start():match.end()],
                                                     replacement)
 


### PR DESCRIPTION
When a member mentions someone from another server that the bot cannot see, the mentioned
appears as @Unknown and the information about the mention is lost. I think we should still retain the
mentioned ID in the transcript, since it is already present.

Also, I think that we should show <@!XXXXXXXXXXXXX> with the `str(member_id)` instead of showing
@Unknown, like it currently is on the Discord client when we see a mentioned
of an unknown user but this is already a much needed fix as it is imo