### PR TITLE
Add message_content intents to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ from discord.ext import commands
 
 intents = discord.Intents.default()
 intents.members = True
+intents.message_content = True
 
 bot = commands.Bot(command_prefix="!", intents=intents)
 


### PR DESCRIPTION
With the API changes that took place in late September, this intent is now required to get message content, which is necessary for this tool, but also for {prefix} commands to work.