### PR TITLE
Implement member caching across multiple instances of MemberConstruct

### DIFF
--- a/chat_exporter/__init__.py
+++ b/chat_exporter/__init__.py
@@ -1,6 +1,6 @@
 from chat_exporter.chat_exporter import export, raw_export, quick_export, link, quick_link
 
-__version__ = "2.6.1"
+__version__ = "2.7.0"
 
 __all__ = (
     export,

--- a/chat_exporter/construct/message.py
+++ b/chat_exporter/construct/message.py
@@ -9,6 +9,7 @@ from chat_exporter.ext.discord_import import discord
 from chat_exporter.construct.assets import Attachment, Component, Embed, Reaction
 from chat_exporter.ext.discord_utils import DiscordUtils
 from chat_exporter.ext.discriminator import discriminator
+from chat_exporter.ext.cache import cache
 from chat_exporter.ext.html_generator import (
     fill_out,
     bot_tag,
@@ -382,6 +383,7 @@ class MessageConstruct:
             ("MESSAGE_ID", str(self.message.id), PARSE_MODE_NONE),
         ])
 
+    @cache()
     async def _gather_member(self, author: discord.Member):
         member = self.guild.get_member(author.id)
 


### PR DESCRIPTION
# Summary
Upon profiling the chat-exporter I found that the largest bottleneck seemed to come from the lack of caching member objects in the `_gather_member` method of the `MessageConstruct` function. This is a huge issue seeing as there are cases where the input user ID is either a webhook's or no longer in the guild, meaning the `fetch_member` function will be called each time, sending an API request to Discord.
This'll cause the message to take at least the duration of the API call, so now the whole process is bottlenecked by I/O related tasks.