### PR TITLE
Add py-cord to imports

### DIFF
--- a/chat_exporter/ext/discord_import.py
+++ b/chat_exporter/ext/discord_import.py
@@ -1,4 +1,4 @@
-discord_modules = ['nextcord', 'disnake', 'discord']
+discord_modules = ['nextcord', 'disnake', 'py-cord', 'discord']
 for module in discord_modules:
     try:
         discord = __import__(module)


### PR DESCRIPTION
[py-cord](https://github.com/Pycord-Development/pycord) is a fork of discord.py that is widely used because of easy slash commands