### PR TITLE
Fix type hinting compatibility with Python < 3.9

### DIFF
--- a/chat_exporter/ext/cache.py
+++ b/chat_exporter/ext/cache.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Any
+from typing import Any, Dict, Tuple
 
 _internal_cache: dict = {}
 
@@ -24,7 +24,7 @@ def clear_cache():
 
 def cache():
     def decorator(func):
-        def _make_key(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+        def _make_key(args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> str:
             def _true_repr(o):
                 if o.__class__.__repr__ is object.__repr__:
                     # this is how MessageConstruct can retain


### PR DESCRIPTION
Fixes https://github.com/mahtoid/DiscordChatExporterPy/issues/100

Tested on 3.8.15 and 3.11.8 on my machine (Windows) and works.