### PR TITLE
Fix a bug within LocalAttachmentHandler and regex search returning None causing AttributeError & add html meta tags to transcript

### DIFF
--- a/chat_exporter/construct/attachment_handler.py
+++ b/chat_exporter/construct/attachment_handler.py
@@ -1,8 +1,9 @@
+import datetime
 import io
 import pathlib
 from typing import Union
 import urllib.parse
-import uuid
+
 
 import aiohttp
 from chat_exporter.ext.discord_import import discord
@@ -34,7 +35,7 @@ class AttachmentToLocalFileHostHandler(AttachmentHandler):
 		:param attachment: discord.Attachment
 		:return: str
 		"""
-		file_name = urllib.parse.quote_plus(f"{uuid.uuid4()}_{attachment.filename}")
+		file_name = urllib.parse.quote_plus(f"{datetime.datetime.utcnow().timestamp()}_{attachment.filename}")
 		asset_path = self.base_path / file_name
 		await attachment.save(asset_path)
 		file_url = f"{self.url_base}/{file_name}"

--- a/chat_exporter/construct/attachment_handler.py
+++ b/chat_exporter/construct/attachment_handler.py
@@ -34,10 +34,10 @@ class AttachmentToLocalFileHostHandler(AttachmentHandler):
 		:param attachment: discord.Attachment
 		:return: str
 		"""
-		file_name = f"{uuid.uuid4()}_{attachment.filename}"
+		file_name = urllib.parse.quote_plus(f"{uuid.uuid4()}_{attachment.filename}")
 		asset_path = self.base_path / file_name
 		await attachment.save(asset_path)
-		file_url = urllib.parse.quote_plus(f"{self.url_base}/{file_name}")
+		file_url = f"{self.url_base}/{file_name}"
 		attachment.url = file_url
 		attachment.proxy_url = file_url
 		return attachment

--- a/chat_exporter/construct/attachment_handler.py
+++ b/chat_exporter/construct/attachment_handler.py
@@ -1,7 +1,8 @@
-import datetime
 import io
 import pathlib
 from typing import Union
+import urllib.parse
+import uuid
 
 import aiohttp
 from chat_exporter.ext.discord_import import discord
@@ -33,10 +34,10 @@ class AttachmentToLocalFileHostHandler(AttachmentHandler):
 		:param attachment: discord.Attachment
 		:return: str
 		"""
-		file_name = f"{int(datetime.datetime.utcnow().timestamp())}_{attachment.filename}".replace(' ', '%20')
+		file_name = f"{uuid.uuid4()}_{attachment.filename}"
 		asset_path = self.base_path / file_name
 		await attachment.save(asset_path)
-		file_url = f"{self.url_base}/{file_name}"
+		file_url = urllib.parse.quote_plus(f"{self.url_base}/{file_name}")
 		attachment.url = file_url
 		attachment.proxy_url = file_url
 		return attachment

--- a/chat_exporter/html/base.html
+++ b/chat_exporter/html/base.html
@@ -13,6 +13,20 @@ If you have any issues or suggestions - open an issue on the Github Repository o
     <title>{{SERVER_NAME}} - {{CHANNEL_NAME}}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width" />
+    <meta name="title" content="{{SERVER_NAME}} - {{CHANNEL_NAME}}">
+    <meta name="description" content="Transcript of channel {{CHANNEL_NAME}} ({{CHANNEL_ID}}) from {{SERVER_NAME}} ({{GUILD_ID}}) with {{MESSAGE_COUNT}} messages. This transcript was generated on {{DATE_TIME}}.">
+    <meta name="theme-color" content="#638dfc" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="{{SERVER_NAME}} - {{CHANNEL_NAME}}" />
+    <meta property="og:description" content="Transcript of channel {{CHANNEL_NAME}} ({{CHANNEL_ID}}) from {{SERVER_NAME}} ({{GUILD_ID}}) with {{MESSAGE_COUNT}} messages. This transcript was generated on {{DATE_TIME}}." />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary" />
+    <meta name='twitter:title' content="{{SERVER_NAME}} - {{CHANNEL_NAME}}" />
+    <meta name='twitter:description' content="Transcript of channel {{CHANNEL_NAME}} ({{CHANNEL_ID}}) from {{SERVER_NAME}} ({{GUILD_ID}}) with {{MESSAGE_COUNT}} messages. This transcript was generated on {{DATE_TIME}}." />
+
 
     <style>
         @font-face {

--- a/chat_exporter/parse/markdown.py
+++ b/chat_exporter/parse/markdown.py
@@ -388,28 +388,34 @@ class ParseMarkdown:
 
                 if "&lt;" in word and "&gt;" in word:
                     pattern = r"&lt;https?:\/\/(.*)&gt;"
-                    match_url = re.search(pattern, word).group(1)
-                    url = f'<a href="https://{match_url}">https://{match_url}</a>'
-                    word = word.replace("https://" + match_url, url)
-                    word = word.replace("http://" + match_url, url)
+                    match_url = re.search(pattern, word)
+                    if match_url:
+                        match_url = match_url.group(1)
+                        url = f'<a href="https://{match_url}">https://{match_url}</a>'
+                        word = word.replace("https://" + match_url, url)
+                        word = word.replace("http://" + match_url, url)
                     output.append(remove_silent_link(word, match_url))
                 elif "https://" in word:
                     pattern = r"https://[^\s>`\"*]*"
-                    word_link = re.search(pattern, word).group()
-                    if word_link.endswith(")"):
+                    word_link = re.search(pattern, word)
+                    if word_link and word_link.group().endswith(")"):
                         output.append(word)
                         continue
-                    word_full = f'<a href="{word_link}">{word_link}</a>'
-                    word = re.sub(pattern, word_full, word)
+                    elif word_link:
+                        word_link = word_link.group()
+                        word_full = f'<a href="{word_link}">{word_link}</a>'
+                        word = re.sub(pattern, word_full, word)
                     output.append(remove_silent_link(word))
                 elif "http://" in word:
                     pattern = r"http://[^\s>`\"*]*"
-                    word_link = re.search(pattern, word).group()
-                    if word_link.endswith(")"):
+                    word_link = re.search(pattern, word)
+                    if word_link and word_link.group().endswith(")"):
                         output.append(word)
                         continue
-                    word_full = f'<a href="{word_link}">{word_link}</a>'
-                    word = re.sub(pattern, word_full, word)
+                    elif word_link:
+                        word_link = word_link.group()
+                        word_full = f'<a href="{word_link}">{word_link}</a>'
+                        word = re.sub(pattern, word_full, word)
                     output.append(remove_silent_link(word))
                 else:
                     output.append(word)


### PR DESCRIPTION
In very raw cases the local attachment handler didn't produce unique (enough) filenames for attachements causing later attachments to overwrite previously stored. By replacing the epoch timestamp with an UUID v4, this is prevented and deals even with multiple transcripts at the same time being generated.

This PR also fixes #109 where re.search finds no match and is returning None. This lead to AttributeErrors.

Lastly this PR adds html meta tags to the base.html to enable link preview in various cases.