### PR TITLE
Bug fixes

### DIFF
--- a/chat_exporter/construct/assets/attachment.py
+++ b/chat_exporter/construct/assets/attachment.py
@@ -88,16 +88,19 @@ class Attachment:
             "arj", "pkg", "z"
         )
 
-        extension = self.attachments.proxy_url.rsplit('.', 1)[1]
-        if extension in acrobat_types:
-            return DiscordUtils.file_attachment_acrobat
-        elif extension in webcode_types:
-            return DiscordUtils.file_attachment_webcode
-        elif extension in code_types:
-            return DiscordUtils.file_attachment_code
-        elif extension in document_types:
-            return DiscordUtils.file_attachment_document
-        elif extension in archive_types:
-            return DiscordUtils.file_attachment_archive
-        else:
-            return DiscordUtils.file_attachment_unknown
+        for tmp in [self.attachments.proxy_url, self.attachments.filename]:
+            if not tmp:
+                continue
+            extension = tmp.rsplit('.', 1)[-1]
+            if extension in acrobat_types:
+                return DiscordUtils.file_attachment_acrobat
+            elif extension in webcode_types:
+                return DiscordUtils.file_attachment_webcode
+            elif extension in code_types:
+                return DiscordUtils.file_attachment_code
+            elif extension in document_types:
+                return DiscordUtils.file_attachment_document
+            elif extension in archive_types:
+                return DiscordUtils.file_attachment_archive
+        
+        return DiscordUtils.file_attachment_unknown

--- a/chat_exporter/construct/message.py
+++ b/chat_exporter/construct/message.py
@@ -181,12 +181,8 @@ class MessageConstruct:
         is_bot = _gather_user_bot(message.author)
         user_colour = await self._gather_user_colour(message.author)
 
-        if not message.content and not getattr(message, 'interaction_metadata', None) and not getattr(message, 'interaction', None):
-            message.content = "Click to see attachment"
-        elif not message.content and ((hasattr(message, 'interaction_metadata') and message.interaction_metadata) or message.interaction):
-            message.content = "Click to see command"
-
         icon = ""
+        dummy = ""
         def get_interaction_status(interaction_message):
             if hasattr(interaction_message, 'interaction_metadata'):
                 return interaction_message.interaction_metadata
@@ -195,8 +191,13 @@ class MessageConstruct:
         interaction_status = get_interaction_status(message)
         if not interaction_status and (message.embeds or message.attachments):
             icon = DiscordUtils.reference_attachment_icon
+            dummy = "Click to see attachment"
         elif interaction_status:
             icon = DiscordUtils.interaction_command_icon
+            dummy = "Click to see command"
+
+        if not message.content:
+            message.content = dummy
 
         _, message_edited_at = self.set_time(message)
 

--- a/chat_exporter/construct/transcript.py
+++ b/chat_exporter/construct/transcript.py
@@ -17,7 +17,7 @@ from chat_exporter.ext.cache import clear_cache
 from chat_exporter.parse.mention import pass_bot
 from chat_exporter.ext.discord_utils import DiscordUtils
 from chat_exporter.ext.html_generator import (
-    fill_out, total, channel_topic, meta_data_temp, fancy_time, channel_subject, PARSE_MODE_NONE
+    fill_out, total, channel_topic, meta_data_temp, fancy_time, channel_subject, PARSE_MODE_NONE, PARSE_MODE_HTML_SAFE
 )
 
 
@@ -167,7 +167,9 @@ class TranscriptDAO:
             ("CHANNEL_ID", str(self.channel.id), PARSE_MODE_NONE),
             ("MESSAGE_PARTICIPANTS", str(len(meta_data)), PARSE_MODE_NONE),
             ("FANCY_TIME", _fancy_time, PARSE_MODE_NONE),
-            ("SD", sd, PARSE_MODE_NONE)
+            ("SD", sd, PARSE_MODE_NONE),
+            ("SERVER_NAME_SAFE", f"{guild_name}", PARSE_MODE_HTML_SAFE),
+            ("CHANNEL_NAME_SAFE", f"{html.escape(self.channel.name)}", PARSE_MODE_HTML_SAFE),
         ])
 
 

--- a/chat_exporter/ext/html_generator.py
+++ b/chat_exporter/ext/html_generator.py
@@ -1,3 +1,5 @@
+import html
+import json
 import os
 
 from chat_exporter.parse.mention import ParseMention
@@ -12,6 +14,7 @@ PARSE_MODE_EMBED = 3
 PARSE_MODE_SPECIAL_EMBED = 4
 PARSE_MODE_REFERENCE = 5
 PARSE_MODE_EMOJI = 6
+PARSE_MODE_HTML_SAFE = 7
 
 
 async def fill_out(guild, base, replacements):
@@ -34,8 +37,13 @@ async def fill_out(guild, base, replacements):
             v = await ParseMarkdown(v).message_reference_flow()
         elif mode == PARSE_MODE_EMOJI:
             v = await ParseMarkdown(v).special_emoji_flow()
+        elif mode == PARSE_MODE_HTML_SAFE:
+            # escape html characters
+            v = html.escape(v, quote=True)
+            # escape characters that could be used for xss
+            v = json.dumps(v, ensure_ascii=False)[1:-1]
 
-        base = base.replace("{{" + k + "}}", v.strip())
+        base = base.replace("{{" + k + "}}", str(v or "").strip())
 
     return base
 

--- a/chat_exporter/html/base.html
+++ b/chat_exporter/html/base.html
@@ -10,22 +10,22 @@ If you have any issues or suggestions - open an issue on the Github Repository o
 <html lang="en">
 
 <head>
-    <title>{{SERVER_NAME}} - {{CHANNEL_NAME}}</title>
+    <title>{{SERVER_NAME_SAFE}} - {{CHANNEL_NAME_SAFE}}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width" />
-    <meta name="title" content="{{SERVER_NAME}} - {{CHANNEL_NAME}}">
-    <meta name="description" content="Transcript of channel {{CHANNEL_NAME}} ({{CHANNEL_ID}}) from {{SERVER_NAME}} ({{GUILD_ID}}) with {{MESSAGE_COUNT}} messages. This transcript was generated on {{DATE_TIME}}.">
+    <meta name="title" content="{{SERVER_NAME_SAFE}} - {{CHANNEL_NAME_SAFE}}">
+    <meta name="description" content="Transcript of channel {{CHANNEL_NAME_SAFE}} ({{CHANNEL_ID}}) from {{SERVER_NAME_SAFE}} ({{GUILD_ID}}) with {{MESSAGE_COUNT}} messages. This transcript was generated on {{DATE_TIME}}.">
     <meta name="theme-color" content="#638dfc" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="{{SERVER_NAME}} - {{CHANNEL_NAME}}" />
-    <meta property="og:description" content="Transcript of channel {{CHANNEL_NAME}} ({{CHANNEL_ID}}) from {{SERVER_NAME}} ({{GUILD_ID}}) with {{MESSAGE_COUNT}} messages. This transcript was generated on {{DATE_TIME}}." />
+    <meta property="og:title" content="{{SERVER_NAME_SAFE}} - {{CHANNEL_NAME_SAFE}}" />
+    <meta property="og:description" content="Transcript of channel {{CHANNEL_NAME_SAFE}} ({{CHANNEL_ID}}) from {{SERVER_NAME_SAFE}} ({{GUILD_ID}}) with {{MESSAGE_COUNT}} messages. This transcript was generated on {{DATE_TIME}}." />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary" />
-    <meta name='twitter:title' content="{{SERVER_NAME}} - {{CHANNEL_NAME}}" />
-    <meta name='twitter:description' content="Transcript of channel {{CHANNEL_NAME}} ({{CHANNEL_ID}}) from {{SERVER_NAME}} ({{GUILD_ID}}) with {{MESSAGE_COUNT}} messages. This transcript was generated on {{DATE_TIME}}." />
+    <meta name='twitter:title' content="{{SERVER_NAME_SAFE}} - {{CHANNEL_NAME_SAFE}}" />
+    <meta name='twitter:description' content="Transcript of channel {{CHANNEL_NAME_SAFE}} ({{CHANNEL_ID}}) from {{SERVER_NAME_SAFE}} ({{GUILD_ID}}) with {{MESSAGE_COUNT}} messages. This transcript was generated on {{DATE_TIME}}." />
 
 
     <style>


### PR DESCRIPTION
Fixes:
- The broken meta or title tags caused by utf8 emojis in the channel or server name. Those were replaced with images like emojis in messages, but due to the `"` in the new text the tags were not recognized correctly
- The issue when embedding the attachment data directly into the transcript that the code would break trying to figure out the file icon for the attachment as the proxy_url wouldn't contain any `.fileextension` anymore. It now falls back to the filename in such cases. Furthermore the IndexError should be avoided by rsplit in combination with indexing with -1 instead of 1.

Improves:
- Refactoring a part of the the message parsing logic of references to make it more readable and easier maintainable.