### PR TITLE
Release 2.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This is mostly seen as a demo function, as opposed to a command you should actua
 
 **Optional Argument(s):**<br/>
 `bot`: `commands.Bot` object to gather members who are no longer in your guild.
+`raise_exceptions`: `bool` flag to raise exceptions instead of printing them to the console and surpressing the exception.
 
 **Return Argument:**<br/>
 `discord.Message`: The message _quick_export_ will send, containing the embed and exported chat file.
@@ -102,6 +103,7 @@ This would be the main function to use within chat-exporter.
 `after`: `datetime.datetime` object which allows to gather messages from after a certain date.<br/>
 `bot`: `commands.Bot` object to gather members who are no longer in your guild.<br/>
 `attachment_handler`: `chat_exporter.AttachmentHandler` object to export assets to in order to make them available after the `channel` got deleted.<br/>
+`raise_exceptions`: `bool` flag to raise exceptions instead of printing them to the console and surpressing the exception.
 
 **Return Argument:**<br/>
 `transcript`: The HTML build-up for you to construct the HTML File with Discord.
@@ -151,6 +153,7 @@ This would be for people who want to filter what content to export.
 `fancy_times`: Boolean value which toggles the 'fancy times' (Today|Yesterday|Day)<br/>
 `bot`: `commands.Bot` object to gather members who are no longer in your guild.
 `attachment_handler`: `chat_exporter.AttachmentHandler` object to export assets to in order to make them available after the `channel` got deleted.<br/>
+`raise_exceptions`: `bool` flag to raise exceptions instead of printing them to the console and surpressing the exception.
 
 **Return Argument:**<br/>
 `transcript`: The HTML build-up for you to construct the HTML File with Discord.

--- a/chat_exporter/__init__.py
+++ b/chat_exporter/__init__.py
@@ -6,7 +6,7 @@ from chat_exporter.chat_exporter import (
     AttachmentToLocalFileHostHandler,
     AttachmentToDiscordChannelHandler)
 
-__version__ = "2.8.4"
+__version__ = "2.9.0"
 
 __all__ = (
     export,

--- a/chat_exporter/chat_exporter.py
+++ b/chat_exporter/chat_exporter.py
@@ -11,6 +11,7 @@ async def quick_export(
     channel: discord.TextChannel,
     guild: Optional[discord.Guild] = None,
     bot: Optional[discord.Client] = None,
+    raise_exceptions: bool = False
 ):
     """
     Create a quick export of your Discord channel.
@@ -18,6 +19,7 @@ async def quick_export(
     :param channel: discord.TextChannel
     :param guild: (optional) discord.Guild
     :param bot: (optional) discord.Client
+    :param raise_exceptions: boolean - raise exceptions if they occur
     :return: discord.Message (posted transcript)
     """
 
@@ -36,7 +38,8 @@ async def quick_export(
             after=None,
             support_dev=True,
             bot=bot,
-            attachment_handler=None
+            attachment_handler=None,
+            raise_exceptions=raise_exceptions
             ).export()
         ).html
 
@@ -64,6 +67,7 @@ async def export(
     after: Optional[datetime.datetime] = None,
     support_dev: Optional[bool] = True,
     attachment_handler: Optional[AttachmentHandler] = None,
+    raise_exceptions: bool = False
 ):
     """
     Create a customised transcript of your Discord channel.
@@ -78,6 +82,7 @@ async def export(
     :param before: (optional) datetime.datetime - allows before time for history
     :param after: (optional) datetime.datetime - allows after time for history
     :param attachment_handler: (optional) attachment_handler.AttachmentHandler - allows custom asset handling
+    :param raise_exceptions: boolean - raise exceptions if they occur
     :return: string - transcript file make up
     """
     if guild:
@@ -96,6 +101,7 @@ async def export(
             support_dev=support_dev,
             bot=bot,
             attachment_handler=attachment_handler,
+            raise_exceptions=raise_exceptions
         ).export()
     ).html
 
@@ -110,6 +116,7 @@ async def raw_export(
     fancy_times: Optional[bool] = True,
     support_dev: Optional[bool] = True,
     attachment_handler: Optional[AttachmentHandler] = None,
+    raise_exceptions: bool = False
 ):
     """
     Create a customised transcript with your own captured Discord messages
@@ -122,6 +129,7 @@ async def raw_export(
     :param military_time: (optional) boolean - set military time (24hour clock)
     :param fancy_times: (optional) boolean - set javascript around time display
     :param attachment_handler: (optional) AttachmentHandler - allows custom asset handling
+    :param raise_exceptions: boolean - raise exceptions if they occur
     :return: string - transcript file make up
     """
     if guild:
@@ -139,6 +147,7 @@ async def raw_export(
             after=None,
             support_dev=support_dev,
             bot=bot,
-            attachment_handler=attachment_handler
+            attachment_handler=attachment_handler,
+            raise_exceptions=raise_exceptions
         ).export()
     ).html

--- a/chat_exporter/construct/transcript.py
+++ b/chat_exporter/construct/transcript.py
@@ -37,7 +37,7 @@ class TranscriptDAO:
         support_dev: bool,
         bot: Optional[discord.Client],
         attachment_handler: Optional[AttachmentHandler],
-        raise_exceptions: bool
+        raise_exceptions: bool = False,
     ):
         self.channel = channel
         self.messages = messages
@@ -189,10 +189,10 @@ class Transcript(TranscriptDAO):
 
         try:
             return await super().build_transcript()
-        except Exception as e:
+        except Exception:
             self.html = "Whoops! Something went wrong..."
             traceback.print_exc()
             print("Please send a screenshot of the above error to https://www.github.com/mahtoid/DiscordChatExporterPy")
             if self.raise_exceptions:
-                raise e
+                raise
             return self

--- a/chat_exporter/construct/transcript.py
+++ b/chat_exporter/construct/transcript.py
@@ -37,6 +37,7 @@ class TranscriptDAO:
         support_dev: bool,
         bot: Optional[discord.Client],
         attachment_handler: Optional[AttachmentHandler],
+        raise_exceptions: bool
     ):
         self.channel = channel
         self.messages = messages
@@ -48,6 +49,7 @@ class TranscriptDAO:
         self.support_dev = support_dev
         self.pytz_timezone = pytz_timezone
         self.attachment_handler = attachment_handler
+        self.raise_exceptions = raise_exceptions
 
         # This is to pass timezone in to mention.py without rewriting
         setattr(discord.Guild, "timezone", self.pytz_timezone)
@@ -187,8 +189,10 @@ class Transcript(TranscriptDAO):
 
         try:
             return await super().build_transcript()
-        except Exception:
+        except Exception as e:
             self.html = "Whoops! Something went wrong..."
             traceback.print_exc()
             print("Please send a screenshot of the above error to https://www.github.com/mahtoid/DiscordChatExporterPy")
+            if self.raise_exceptions:
+                raise e
             return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "chat_exporter"
 description = "A simple Discord chat exporter for Python Discord bots."
-version = "2.8.4"
+version = "2.9.0"
 readme = "README.md"
 authors = [
     { name="mahtoid", email="info@mahto.id" }


### PR DESCRIPTION
This pull request introduces a new `raise_exceptions` flag across multiple functions and classes in the `chat_exporter` package. This flag allows exceptions to be raised instead of being suppressed and logged, providing developers with more control over error handling. Additionally, the package version has been updated to `2.9.0`.

### New Feature: `raise_exceptions` Flag

* **README Documentation Updates**: Added descriptions for the new `raise_exceptions` flag to the README file for the `quick_export`, `export`, and `raw_export` functions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R57) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R156)
* **Function Updates**:
  - [`chat_exporter/chat_exporter.py`](diffhunk://#diff-e0acb89e655d54252cb4cc041a11214b231a9b81e4657f0762cfb3479bbe9f11R14-R22): Added the `raise_exceptions` parameter to the `quick_export`, `export`, and `raw_export` functions, enabling exception raising during transcript generation. [[1]](diffhunk://#diff-e0acb89e655d54252cb4cc041a11214b231a9b81e4657f0762cfb3479bbe9f11R14-R22) [[2]](diffhunk://#diff-e0acb89e655d54252cb4cc041a11214b231a9b81e4657f0762cfb3479bbe9f11R70) [[3]](diffhunk://#diff-e0acb89e655d54252cb4cc041a11214b231a9b81e4657f0762cfb3479bbe9f11R119)
  - [`chat_exporter/construct/transcript.py`](diffhunk://#diff-1fcdd75e61285379848b53966db5eed657ffa70fa3620e5852a892682f9daedaR40): Integrated the `raise_exceptions` flag into the `Transcript` class and its `export` method to raise exceptions when enabled. [[1]](diffhunk://#diff-1fcdd75e61285379848b53966db5eed657ffa70fa3620e5852a892682f9daedaR40) [[2]](diffhunk://#diff-1fcdd75e61285379848b53966db5eed657ffa70fa3620e5852a892682f9daedaR196-R197)

### Version Update

* **Version Bump**:
  - Updated the package version from `2.8.4` to `2.9.0` in `chat_exporter/__init__.py` and `pyproject.toml`. [[1]](diffhunk://#diff-b1584ead91b4fe464cfbcc3579fb64bf59986a03e9972ba9ab30114feb94e6ffL9-R9) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L8-R8)