### PR TITLE
fix transcript rendering edge cases

### DIFF
--- a/chat_exporter/construct/assets/component.py
+++ b/chat_exporter/construct/assets/component.py
@@ -246,7 +246,7 @@ class Component:
             option_emoji = self._stringify_emoji(self._get_attr(option, "emoji", None))
             is_default = bool(self._get_attr(option, "default", False))
             default_class = "dropdownContentSelected" if is_default else ""
-            check_mark = "✓" if is_default else ""
+            check_mark = "&#10003;" if is_default else ""
 
             label_escaped = html.escape(str(label)) if label else ""
             description_escaped = html.escape(str(description)) if description else ""
@@ -551,7 +551,7 @@ class Component:
         if not spoiler and description:
             description_overlay = (
                 f'<div class="chatlog__component-{css_class_prefix}-description">'
-                f'{{html.escape(str(description))}}</div>'
+                f'{html.escape(str(description))}</div>'
             )
 
         return {

--- a/chat_exporter/construct/attachment_handler.py
+++ b/chat_exporter/construct/attachment_handler.py
@@ -38,7 +38,7 @@ class AttachmentToLocalFileHostHandler(AttachmentHandler):
         :param attachment: discord.Attachment
         :return: str
         """
-        file_name = urllib.parse.quote_plus(f"{datetime.datetime.utcnow().timestamp()}_{attachment.filename}")
+        file_name = urllib.parse.quote_plus(f"{datetime.datetime.now(datetime.timezone.utc).timestamp()}_{attachment.filename}")
         asset_path = self.base_path / file_name
         await attachment.save(asset_path)
         file_url = f"{self.url_base}/{file_name}"
@@ -85,6 +85,7 @@ class AttachmentToWebhookHandler(AttachmentHandler):
         """Implement this to process the asset and return a url to the stored attachment.
         :param attachment: discord.Attachment
         :return: str"""
+        message = None
         try:
             if attachment.size > self.size_limit:
                 file = discord.File(self.placeholder_path, filename="too_large.png")
@@ -105,4 +106,6 @@ class AttachmentToWebhookHandler(AttachmentHandler):
             # discords http errors, including missing permissions
             raise e
         else:
+            if message is None:
+                raise aiohttp.ClientConnectionError("Webhook connection failed after 3 retries.")
             return message.attachments[0]

--- a/chat_exporter/construct/message.py
+++ b/chat_exporter/construct/message.py
@@ -270,6 +270,8 @@ class MessageConstruct:
             message_edited_at = _set_edit_at(message_edited_at)
 
         avatar_url = message.author.display_avatar if message.author.display_avatar else DiscordUtils.default_avatar
+        reference_content = message.content.replace("\r\n", "\n").replace("\r", "\n")
+        reference_content = reference_content.replace("\n", " ").replace("<br>", " ")
         self.message.reference = await fill_out(
             self.guild,
             message_reference,
@@ -279,7 +281,7 @@ class MessageConstruct:
                 ("NAME_TAG", await discriminator(message.author.name, message.author.discriminator), PARSE_MODE_NONE),
                 ("NAME", str(html.escape(message.author.display_name))),
                 ("USER_COLOUR", user_colour, PARSE_MODE_NONE),
-                ("CONTENT", message.content.replace("\n", "").replace("<br>", ""), PARSE_MODE_REFERENCE),
+                ("CONTENT", reference_content, PARSE_MODE_REFERENCE),
                 ("EDIT", message_edited_at, PARSE_MODE_NONE),
                 ("ICON", icon, PARSE_MODE_NONE),
                 ("USER_ID", str(message.author.id), PARSE_MODE_NONE),
@@ -351,7 +353,7 @@ class MessageConstruct:
                 f"https://cdn.jsdelivr.net/gh/mahtoid/DiscordUtils@master/stickers/{sticker.pack_id}/{sticker.id}.gif"
             )
 
-        self.rendered_content = await fill_out(
+        sticker_html = await fill_out(
             self.guild,
             img_attachment,
             [
@@ -359,6 +361,7 @@ class MessageConstruct:
                 ("ATTACH_URL_THUMB", str(sticker_image_url), PARSE_MODE_NONE),
             ],
         )
+        self.rendered_content += sticker_html
 
     @staticmethod
     def calculate_grid_splits(n):
@@ -687,7 +690,7 @@ class MessageConstruct:
         return created_at_str, edited_at_str
 
     def to_local_time_str(self, time):
-        if not self.message.created_at.tzinfo:
+        if not time.tzinfo:
             time = timezone("UTC").localize(time)
 
         local_time = time.astimezone(timezone(self.pytz_timezone))

--- a/chat_exporter/construct/transcript.py
+++ b/chat_exporter/construct/transcript.py
@@ -73,7 +73,7 @@ class TranscriptDAO:
     async def export_transcript(self, message_html: str, meta_data: str):
         guild_icon = (
             self.channel.guild.icon
-            if (self.channel.guild.icon and len(self.channel.guild.icon) > 2)
+            if self.channel.guild.icon
             else DiscordUtils.default_avatar
         )
 

--- a/chat_exporter/ext/cache.py
+++ b/chat_exporter/ext/cache.py
@@ -54,7 +54,7 @@ def cache():
                 return _wrap_new_coroutine(value)
 
         wrapper.cache = _internal_cache
-        wrapper.clear_cache = _internal_cache.clear()
+        wrapper.clear_cache = _internal_cache.clear
         return wrapper
 
     return decorator

--- a/chat_exporter/parse/ast.py
+++ b/chat_exporter/parse/ast.py
@@ -4,6 +4,7 @@ import time
 from typing import List
 
 import pytz
+import html
 
 
 class Node:
@@ -184,11 +185,7 @@ class UserMentionNode(Node):
 
         if member:
             member_name = member.display_name
-            escaped_name = (
-                member_name.replace("<", self.ESCAPE_LT)
-                .replace(">", self.ESCAPE_GT)
-                .replace("&", self.ESCAPE_AMP)
-            )
+            escaped_name = html.escape(member_name)
             return f'<span class="mention" title="{self.user_id}">@{escaped_name}</span>'
         else:
             return f'<span class="mention" title="{self.user_id}">&lt;@{self.user_id}&gt;</span>'
@@ -236,7 +233,7 @@ class TimeMentionNode(Node):
         self.original = original
 
     def render(self, guild=None, bot=None):
-        timestamp = self.timestamp - 1
+        timestamp = self.timestamp
         try:
             time_stamp = time.gmtime(timestamp)
             datetime_stamp = datetime.datetime(2010, *time_stamp[1:6], tzinfo=pytz.utc)


### PR DESCRIPTION
I like to go through the code a bit before using a library, and while doing that here I found a few issues worth cleaning up. This updates some rendering edge cases in transcripts, keeps sticker messages from replacing normal message content, fixes timestamp output, improves reply preview spacing, makes the webhook attachment retry path fail properly, and small component-related fixes..
that's all I could see by myself, and I just wanted those to be fixed to make it almost perfect. I have ran `ty check` command, but didn't know if you wanted me to resolve typechecking issues
after-all, some fixes are imo and can be reverted, it's your choice

thanks for the library btw, I appreciate it, it's great !